### PR TITLE
Prototype an cosmetic armor reworked compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ mixin {
     add sourceSets.main, "enigmaticgraves.refmap.json"
 }
 
-version = '1.6.3'
+version = '1.6.4'
 group = 'dev.quarris.enigmaticgraves' // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = 'EnigmaticGraves'
 
@@ -112,7 +112,7 @@ dependencies {
     compileOnly fg.deobf("top.theillusivec4.curios:curios-forge:1.16.5-4.0.5.1:api")
     compileOnly fg.deobf("mcjty.theoneprobe:TheOneProbe-1.16:1.16-3.1.4-22:api")
     compile fg.deobf("mcp.mobius.waila:Hwyla:1.10.11-+")
-    //compileOnly 'curse.maven:cosmetic-armor-reworked-237307:3398001'
+    compileOnly 'curse.maven:cosmetic-armor-reworked-237307:3398001'
 
     // Testing Dependencies
     runtimeOnly fg.deobf('curse.maven:cofh-core-69162:3249453')

--- a/src/main/java/dev/quarris/enigmaticgraves/compat/CompatManager.java
+++ b/src/main/java/dev/quarris/enigmaticgraves/compat/CompatManager.java
@@ -10,6 +10,7 @@ public class CompatManager {
     public static final String CURIOS_ID = "curios";
     public static final String TOP_ID = "theoneprobe";
     public static final String WAILA_ID = "waila";
+    public static final String COSMETICARMORREWORKED_ID = "cosmeticarmorreworked";
 
     public static boolean isModLoaded(String mod) {
         return ModList.get().isLoaded(mod);
@@ -27,10 +28,18 @@ public class CompatManager {
         return isModLoaded(TOP_ID);
     }
 
+    public static boolean isCosmeticArmorReworkedLoaded() {
+        return isModLoaded(COSMETICARMORREWORKED_ID);
+    }
+
+
     public static void cacheModdedHandlers(PlayerEntity player) {
         ModRef.LOGGER.debug("Caching modded handlers for " + player.getName().getString());
         if (CompatManager.isCuriosLoaded()) {
             CurioCompat.cacheCurios(player);
+        }
+        if(CompatManager.isCosmeticArmorReworkedLoaded()){
+            CosmeticArmorReworkedCompat.cacheCosmeticArmorReworkeds(player);
         }
     }
 

--- a/src/main/java/dev/quarris/enigmaticgraves/compat/CosmeticArmorReworkedCompat.java
+++ b/src/main/java/dev/quarris/enigmaticgraves/compat/CosmeticArmorReworkedCompat.java
@@ -1,0 +1,32 @@
+package dev.quarris.enigmaticgraves.compat;
+
+import dev.quarris.enigmaticgraves.grave.data.*;
+import lain.mods.cos.api.*;
+import lain.mods.cos.api.inventory.*;
+import net.minecraft.entity.player.*;
+import net.minecraft.item.*;
+
+import java.util.*;
+
+public class CosmeticArmorReworkedCompat{
+
+    public static final Map<UUID, CAStacksBase> CACHED_COSMETICARMORREWORKEDS = new HashMap<>();
+
+    public static void cacheCosmeticArmorReworkeds(PlayerEntity player) {
+        try {
+            CAStacksBase cached = new CAStacksBase();
+            cached.deserializeNBT(CosArmorAPI.getCAStacks(player.getUniqueID()).serializeNBT());
+            CACHED_COSMETICARMORREWORKEDS.put(player.getUniqueID(), cached);
+        } catch (Exception ignored) {}
+    }
+
+
+    public static IGraveData generateCosmeticArmorReworkedGraveData(PlayerEntity player, Collection<ItemStack> drops) {
+        if (CACHED_COSMETICARMORREWORKEDS.containsKey(player.getUniqueID())) {
+            IGraveData data = new CosmeticArmorReworkedGraveData(CACHED_COSMETICARMORREWORKEDS.get(player.getUniqueID()), drops);
+            CACHED_COSMETICARMORREWORKEDS.remove(player.getUniqueID());
+            return data;
+        }
+        return null;
+    }
+}

--- a/src/main/java/dev/quarris/enigmaticgraves/grave/GraveManager.java
+++ b/src/main/java/dev/quarris/enigmaticgraves/grave/GraveManager.java
@@ -2,6 +2,7 @@ package dev.quarris.enigmaticgraves.grave;
 
 import dev.quarris.enigmaticgraves.compat.CompatManager;
 import dev.quarris.enigmaticgraves.compat.CurioCompat;
+import dev.quarris.enigmaticgraves.compat.CosmeticArmorReworkedCompat;
 import dev.quarris.enigmaticgraves.config.GraveConfigs;
 import dev.quarris.enigmaticgraves.config.GraveConfigs.Common.ExperienceHandling;
 import dev.quarris.enigmaticgraves.content.GraveEntity;
@@ -9,6 +10,7 @@ import dev.quarris.enigmaticgraves.grave.data.CurioGraveData;
 import dev.quarris.enigmaticgraves.grave.data.ExperienceGraveData;
 import dev.quarris.enigmaticgraves.grave.data.IGraveData;
 import dev.quarris.enigmaticgraves.grave.data.PlayerInventoryGraveData;
+import dev.quarris.enigmaticgraves.grave.data.CosmeticArmorReworkedGraveData;
 import dev.quarris.enigmaticgraves.utils.ModRef;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.pattern.BlockPattern;
@@ -43,6 +45,9 @@ public class GraveManager {
         GRAVE_DATA_SUPPLIERS.put(ExperienceGraveData.NAME, ExperienceGraveData::new);
         if (CompatManager.isCuriosLoaded()) {
             GRAVE_DATA_SUPPLIERS.put(CurioGraveData.NAME, CurioGraveData::new);
+        }
+        if (CompatManager.isCosmeticArmorReworkedLoaded()) {
+            GRAVE_DATA_SUPPLIERS.put(CosmeticArmorReworkedGraveData.NAME, CosmeticArmorReworkedGraveData::new);
         }
     }
 
@@ -131,6 +136,13 @@ public class GraveManager {
             IGraveData curiosData = CurioCompat.generateCurioGraveData(player, drops);
             if (curiosData != null) {
                 dataList.add(curiosData);
+            }
+        }
+
+        if (CompatManager.isCosmeticArmorReworkedLoaded()) {
+            IGraveData cosmeticArmorReworkedsData = CosmeticArmorReworkedCompat.generateCosmeticArmorReworkedGraveData(player, drops);
+            if (cosmeticArmorReworkedsData != null) {
+                dataList.add(cosmeticArmorReworkedsData);
             }
         }
 

--- a/src/main/java/dev/quarris/enigmaticgraves/grave/data/CosmeticArmorReworkedGraveData.java
+++ b/src/main/java/dev/quarris/enigmaticgraves/grave/data/CosmeticArmorReworkedGraveData.java
@@ -1,0 +1,74 @@
+package dev.quarris.enigmaticgraves.grave.data;
+
+import dev.quarris.enigmaticgraves.utils.*;
+import lain.mods.cos.api.*;
+import lain.mods.cos.api.inventory.*;
+import net.minecraft.entity.player.*;
+import net.minecraft.item.*;
+import net.minecraft.nbt.*;
+import net.minecraft.util.*;
+
+import java.util.*;
+
+public class CosmeticArmorReworkedGraveData implements IGraveData {
+
+    public static final ResourceLocation NAME = ModRef.res("cosmeticarmorreworked");
+    public final CAStacksBase caStacksBase = new CAStacksBase();
+
+    public CosmeticArmorReworkedGraveData(CAStacksBase caStacksBase, Collection<ItemStack> drops) {
+        this.caStacksBase.deserializeNBT(caStacksBase.serializeNBT());
+
+        Iterator<ItemStack> ite = drops.iterator();
+        while(ite.hasNext()){
+            ItemStack drop = ite.next();
+
+            for (int slot = 0; slot < 4; slot++){
+                ItemStack stack = caStacksBase.getStackInSlot(slot);
+                if (ItemStack.areItemStacksEqual(stack, drop)) {
+                    ite.remove();
+                }
+            }
+        }
+    }
+
+    public CosmeticArmorReworkedGraveData(CompoundNBT nbt) {
+        this.deserializeNBT(nbt);
+    }
+
+    @Override
+    public void restore(PlayerEntity player) {
+        CAStacksBase caStacksBase = CosArmorAPI.getCAStacks(player.getUniqueID());
+
+        for (int slot = 0; slot < 4; slot++){
+            ItemStack wearing = caStacksBase.getStackInSlot(slot);
+            ItemStack looting = this.caStacksBase.getStackInSlot(slot);
+            if(!wearing.isEmpty() && !looting.isEmpty()){
+                // the player equipped cosmetic armor before claiming the grave,
+                // here we de-equip any worn item in favor of what is inside the grave.
+                PlayerInventoryExtensions.tryAddItemToPlayerInvElseDrop(player, -1, wearing);
+            }else if(!wearing.isEmpty()){
+                // if the player is wearing something in a cosmetic armor slot that is not in the grave,
+                // then it gets put in the serializer so the final line of this function doesn't delete it.
+                this.caStacksBase.setStackInSlot(slot, wearing);
+            }
+        }
+
+        caStacksBase.deserializeNBT(this.caStacksBase.serializeNBT());
+    }
+
+    @Override
+    public ResourceLocation getName() {
+        return NAME;
+    }
+
+    @Override
+    public CompoundNBT write(CompoundNBT nbt) {
+        nbt.put("caStacksBase", caStacksBase.serializeNBT());
+        return nbt;
+    }
+
+    @Override
+    public void read(CompoundNBT nbt) {
+        caStacksBase.deserializeNBT(nbt.getCompound("caStacksBase"));
+    }
+}


### PR DESCRIPTION
> an attempt at implementing #7

i've tried to understand as much from the curios compat as i could and coped & modified those bits for cosmetic armor.

since the gravedata class is rather short compared to curios i have probably overlooked something, so this is a draft.
(e.g. when wearing a gold helmet in your cosmetic slot & having one in your inventory you keep both when you die, despite me not having copied over a `stackSlotsChecked` equivalent, should that not cause all other gold helmets to dissapear?)

anyways: this code works (ish), during my limited testing it did what it was supposed to, so i'm happy with this attempt. 🤔  

since the issue mentioned its a commission & this pull shouldn't be merged as-is without some extra work it probably won't see the light of day anytime soon, but if someone eventually does pay up this draft would be a nice starting point to code from.

![2021-10-23_14 36 47](https://user-images.githubusercontent.com/3179271/138556428-a9ffda04-bb35-4945-9031-635674943b72.png)

