### PR TITLE
journeymap compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -113,6 +113,7 @@ dependencies {
     compileOnly fg.deobf("mcjty.theoneprobe:TheOneProbe-1.16:1.16-3.1.4-22:api")
     compile fg.deobf("mcp.mobius.waila:Hwyla:1.10.11-+")
     compileOnly 'curse.maven:cosmetic-armor-reworked-237307:3398001'
+    compileOnly 'curse.maven:journeymap-32274:3397059'
 
     // Testing Dependencies
     runtimeOnly fg.deobf('curse.maven:cofh-core-69162:3249453')

--- a/src/main/java/dev/quarris/enigmaticgraves/compat/CompatManager.java
+++ b/src/main/java/dev/quarris/enigmaticgraves/compat/CompatManager.java
@@ -11,6 +11,7 @@ public class CompatManager {
     public static final String TOP_ID = "theoneprobe";
     public static final String WAILA_ID = "waila";
     public static final String COSMETICARMORREWORKED_ID = "cosmeticarmorreworked";
+    public static final String JOURNEYMAP_ID = "journeymap";
 
     public static boolean isModLoaded(String mod) {
         return ModList.get().isLoaded(mod);
@@ -32,6 +33,9 @@ public class CompatManager {
         return isModLoaded(COSMETICARMORREWORKED_ID);
     }
 
+    public static boolean isJourneymapLoaded() {
+        return isModLoaded(JOURNEYMAP_ID);
+    }
 
     public static void cacheModdedHandlers(PlayerEntity player) {
         ModRef.LOGGER.debug("Caching modded handlers for " + player.getName().getString());

--- a/src/main/java/dev/quarris/enigmaticgraves/compat/JourneymapCompat.java
+++ b/src/main/java/dev/quarris/enigmaticgraves/compat/JourneymapCompat.java
@@ -1,0 +1,35 @@
+package dev.quarris.enigmaticgraves.compat;
+
+import dev.quarris.enigmaticgraves.content.*;
+import dev.quarris.enigmaticgraves.utils.*;
+import journeymap.client.waypoint.*;
+
+import java.util.*;
+
+public class JourneymapCompat {
+
+    public static void restored(GraveEntity grave){
+        WaypointStore.INSTANCE.getAll().stream()
+        .filter(waypoint -> waypoint.getType() == Waypoint.Type.Death)
+        .filter(Waypoint::isInPlayerDimension)
+        .filter(waypoint -> {
+            double x = grave.getX() - waypoint.getBlockCenteredX();
+            double z = grave.getZ() - waypoint.getBlockCenteredZ();
+
+            // filter matching column
+            return 1f > x * x + z * z;
+        })
+        .min(Comparator.comparingDouble(waypoint -> {
+            double x = grave.getX() - waypoint.getBlockCenteredX();
+            double y = grave.getX() - waypoint.getBlockCenteredY();
+            double z = grave.getZ() - waypoint.getBlockCenteredZ();
+
+            // find the closest waypoint
+            return x * x + y * y + z * z;
+        }))
+        .ifPresent(waypoint -> {
+            WaypointStore.INSTANCE.remove(waypoint);
+            ModRef.LOGGER.info("Removed waypoint \"" + waypoint.getName() + "\" at " + waypoint.getBlockPos());
+        });
+    }
+}

--- a/src/main/java/dev/quarris/enigmaticgraves/compat/JourneymapCompat.java
+++ b/src/main/java/dev/quarris/enigmaticgraves/compat/JourneymapCompat.java
@@ -21,7 +21,7 @@ public class JourneymapCompat {
         })
         .min(Comparator.comparingDouble(waypoint -> {
             double x = grave.getX() - waypoint.getBlockCenteredX();
-            double y = grave.getX() - waypoint.getBlockCenteredY();
+            double y = grave.getY() - waypoint.getBlockCenteredY();
             double z = grave.getZ() - waypoint.getBlockCenteredZ();
 
             // find the closest waypoint

--- a/src/main/java/dev/quarris/enigmaticgraves/content/GraveEntity.java
+++ b/src/main/java/dev/quarris/enigmaticgraves/content/GraveEntity.java
@@ -1,5 +1,7 @@
 package dev.quarris.enigmaticgraves.content;
 
+import dev.quarris.enigmaticgraves.compat.CompatManager;
+import dev.quarris.enigmaticgraves.compat.JourneymapCompat;
 import dev.quarris.enigmaticgraves.config.GraveConfigs;
 import dev.quarris.enigmaticgraves.grave.GraveManager;
 import dev.quarris.enigmaticgraves.grave.data.IGraveData;
@@ -145,8 +147,14 @@ public class GraveEntity extends Entity {
         for (IGraveData data : this.contents) {
             data.restore(player);
         }
+
         GraveManager.setGraveRestored(this.getOwnerUUID(), this);
         this.restored = true;
+
+        if (CompatManager.isJourneymapLoaded()) {
+            JourneymapCompat.restored(this);
+        }
+
         this.remove();
     }
 


### PR DESCRIPTION
> #13, compatibility with journeymap (the waypoints mod that manages death points for the enigmatica 6 pack)

the draft is currently singleplayer-ready, multiplayer compatibility will probably take some more steps like doing this:

```
    ...
    private void restoreGrave(PlayerEntity player) {
        if(!this.isAlive()) return;

        if (CompatManager.isJourneymapLoaded()) {
            JourneymapCompat.restored(this);
        }
        
        if(this.level.isClientSide()) return;
    ...
```

also i am not entirely sure if `WaypointStore.INSTANCE` exists on the server since at the time of writing i didn't have a forge server setup for testing this integration, and enigmatica 6 does have journeymap loaded on the server, so only checking the mod_id with the assumption the mod is not on the server won't work.

also not sure what would happen if 2 players play on a server and one sneaks on a grave if that would trigger each player's code to check for themselves, although it probably won't be harmful unless they also have a death waypoint at that exact coordinate.

i am planning to test it on a local non-pack development forge server in the next few days, but i'll leave this draft here for now in case you have something to add or comment.

also it might need a client-server event packet, since maybe the `restoreGrave` can trigger on the client and not on the server in case there is a mild packet loss or position disagreement & the waypoint gets removed without the grave being claimed by the server, probably not a huge issue since you're at the grave when it happens, but still a bug.

```
[28Oct2021 20:59:48.601] [Server thread/INFO] [dev.quarris.enigmaticgraves.EnigmaticGraves/]: Removed waypoint "Death 20:59:44 10-28-2021" at BlockPos{x=117, y=76, z=249}
```